### PR TITLE
adjust log level for I_LOG_MESSAGE

### DIFF
--- a/main.js
+++ b/main.js
@@ -483,7 +483,7 @@ function main() {
                                 break;
 
                             case 'I_LOG_MESSAGE':       //   9   Sent by the gateway to the Controller to trace-log a message
-                                adapter.log.info('Log ' + (ip ? ' from ' + ip + ' ' : '') + ':' + result[i].payload);
+                                adapter.debug.info('Log ' + (ip ? ' from ' + ip + ' ' : '') + ':' + result[i].payload);
                                 break;
 
                             case 'I_ID_REQUEST':

--- a/main.js
+++ b/main.js
@@ -483,7 +483,7 @@ function main() {
                                 break;
 
                             case 'I_LOG_MESSAGE':       //   9   Sent by the gateway to the Controller to trace-log a message
-                                adapter.debug.info('Log ' + (ip ? ' from ' + ip + ' ' : '') + ':' + result[i].payload);
+                                adapter.log.debug('Log ' + (ip ? ' from ' + ip + ' ' : '') + ':' + result[i].payload);
                                 break;
 
                             case 'I_ID_REQUEST':


### PR DESCRIPTION
In a huge mysensor environment the logs are filled up with to many messages for communication between gateway and sensor. Log level "debug" should be enough here.